### PR TITLE
cache busting on injected scripts

### DIFF
--- a/lib/browser/deps/livereload-client.js
+++ b/lib/browser/deps/livereload-client.js
@@ -35,7 +35,7 @@ function loadScript(src, lrload) {
 
   function tryLoad() {
     var script = document.createElement('script')
-    script.setAttribute('src', src);
+    script.setAttribute('src', src + '?bust=' + (new Date()));
     script.addEventListener('error', function() {
       if (numTries < 30) {
         numTries++


### PR DESCRIPTION
Most static file servers (beefy, http-server, ecstatic, etc) seem to use a long cache-control header which breaks this tool. This fix ensures the injected scripts are not cached; but maybe there is a cleaner way of doing this?

fixes #9 