### PR TITLE
consume data to avoid maxAgents hang

### DIFF
--- a/lib/server/notify.js
+++ b/lib/server/notify.js
@@ -17,7 +17,10 @@ module.exports = function(hostname, port, done) {
     }
   };
 
-  var req = http.request(options, function() {
+  var req = http.request(options, function(res) {
+    res.on('data', function() { 
+        /* consume data */
+    });
     if (typeof done === 'function') {
       done();
     }


### PR DESCRIPTION
I'm testing this with a custom dev server and it hangs after 5 hot-reloads. This is because the data isn't being consumed, see here:
http://stackoverflow.com/questions/16965582/node-js-http-get-hangs-after-5-requests-to-remote-site

Another option is to bring in [hyperquest](https://github.com/substack/hyperquest) which doesn't have pooling issues.