### PR TITLE
improving cache bust query param

### DIFF
--- a/lib/browser/deps/livereload-client.js
+++ b/lib/browser/deps/livereload-client.js
@@ -1,6 +1,7 @@
 
 var WebSocket   = require('ws'),
-    forceUpdate = require('./force-update-app')
+    forceUpdate = require('./force-update-app'),
+    addQuery    = require('append-query')
 
 module.exports = {
   init: function(lrload, port) {
@@ -35,7 +36,8 @@ function loadScript(src, lrload) {
 
   function tryLoad() {
     var script = document.createElement('script')
-    script.setAttribute('src', src);
+    var bust = { __livereactloadPreventCache: Date.now() };
+    script.setAttribute('src', addQuery(src, bust));
     script.addEventListener('error', function() {
       if (numTries < 30) {
         numTries++

--- a/lib/browser/deps/livereload-client.js
+++ b/lib/browser/deps/livereload-client.js
@@ -1,7 +1,6 @@
 
 var WebSocket   = require('ws'),
-    forceUpdate = require('./force-update-app'),
-    addQuery    = require('append-query')
+    forceUpdate = require('./force-update-app')
 
 module.exports = {
   init: function(lrload, port) {
@@ -29,6 +28,14 @@ function getScriptURL() {
   }
 }
 
+function cacheBust(uri) {
+  var idx = uri.indexOf('?')
+  if (idx === -1)
+    uri += '?'
+  else if (idx !== uri.length-1)
+    uri += '&'
+  return uri + '__livereactloadPreventCache=' + Date.now()
+}
 
 function loadScript(src, lrload) {
   var numTries = 0
@@ -36,8 +43,7 @@ function loadScript(src, lrload) {
 
   function tryLoad() {
     var script = document.createElement('script')
-    var bust = { __livereactloadPreventCache: Date.now() };
-    script.setAttribute('src', addQuery(src, bust));
+    script.setAttribute('src', cacheBust(src));
     script.addEventListener('error', function() {
       if (numTries < 30) {
         numTries++

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
   "main": "index.js",
   "scripts": {},
   "dependencies": {
-    "append-query": "^1.1.0",
     "cli-color": "0.3.3",
     "livereactload-api": "0.2.1",
     "react-hot-api": "0.4.3",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   "main": "index.js",
   "scripts": {},
   "dependencies": {
+    "append-query": "^1.1.0",
     "cli-color": "0.3.3",
     "livereactload-api": "0.2.1",
     "react-hot-api": "0.4.3",


### PR DESCRIPTION
- uses `__livereactloadPreventCache`
- uses `Date.now()` for timestamp
- uses append-query to avoid breaking when query param already exists

If you have a preferred way of appending query params in the browser (i.e. without url / querystring modules) I could change it to that instead. 

fixes #9 