### PR TITLE
Fixes for Windows paths

### DIFF
--- a/lib/browserify/transform.js
+++ b/lib/browserify/transform.js
@@ -12,8 +12,8 @@ module.exports = function(file, opts) {
       content = ''
 
   var isLiveReactloadModule = path.resolve(file).indexOf(path.resolve(__dirname, '..')) === 0
-  var isReactModule         = file.indexOf('node_modules/react/') !== -1
-  var isBrowserifyModule    = file.indexOf('node_modules/browserify/') !== -1
+  var isReactModule         = file.indexOf(getModulePath('react')) !== -1
+  var isBrowserifyModule    = file.indexOf(getModulePath('browserify')) !== -1
 
   return through(
     function(dat, enc, next) {
@@ -28,6 +28,9 @@ module.exports = function(file, opts) {
   )
 }
 
+function getModulePath(mod) {
+  return path.sep + path.join('node_modules', mod) + path.sep
+}
 
 function injectLiveReloading(content, port, file, meta) {
   var addReloadDependencies = ';require("' + pjson.name + '/lib/browser/add-reactload-deps")(' + port + ', require("react"), require("react/lib/ReactMount"));',

--- a/lib/browserify/transform.js
+++ b/lib/browserify/transform.js
@@ -31,7 +31,7 @@ module.exports = function(file, opts) {
 
 function injectLiveReloading(content, port, file, meta) {
   var addReloadDependencies = ';require("' + pjson.name + '/lib/browser/add-reactload-deps")(' + port + ', require("react"), require("react/lib/ReactMount"));',
-      reloadifyExports      = ';require("' + pjson.name + '/lib/browser/reloadify-exports")("' + file + '", module);';
+      reloadifyExports      = ';require("' + pjson.name + '/lib/browser/reloadify-exports")(' + JSON.stringify(file) + ', module);';
 
   var canBeInjected = !meta.isLiveReactloadModule && !meta.isReactModule && !meta.isBrowserifyModule
 


### PR DESCRIPTION
This PR contains 2 fixes for issues I found when trying to use this on Windows:

1) The JS that was being injected with `reloadifyExports` wasn't being properly escaped. With Windows full-paths containing gratuitous '\'s, this meant that it was generating invalid JS and causing browserify to fail.

2) The checks for various containing modules (namely react and browserify) had baked in assumptions about path separators which weren't true on Windows, and thus no modules were being marked as being part of react or browserify, breaking them in the browser.