### PR TITLE
Doesn't require browserify tranform options

### DIFF
--- a/lib/browserify/transform.js
+++ b/lib/browserify/transform.js
@@ -8,7 +8,7 @@ var util     = require('util'),
 
 
 module.exports = function(file, opts) {
-  var port    = opts.config && opts.config.port ? opts.config.port : defaults.reloadPort,
+  var port    = opts && opts.config && opts.config.port ? opts.config.port : defaults.reloadPort,
       content = ''
 
   var isLiveReactloadModule = path.resolve(file).indexOf(path.resolve(__dirname, '..', '..')) === 0


### PR DESCRIPTION
This makes the transform options optional.

I was having trouble using livereactload with grunt-watchify. grunt-watchify uses an old version of browserify that doesn't support transform options. 