### PR TITLE
Feature/bump ws version

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "react-hot-api": "0.5.0-alpha-3",
     "syntax-error": "1.1.4",
     "through2": "2.0.0",
-    "ws": "0.7.2",
+    "ws": "0.8.0",
     "yargs": "3.11.0"
   },
   "devDependencies": {


### PR DESCRIPTION
On Node@v4.1.0 and Npm@v3.3.0 this package currently fails to install, due to a dependency on socket.io@v0.7.2 which depends on buffer-util@1.1.0. There is a fix in buffer-util@1.2.0 which is used by socket.io@v0.8.0.

I was unable to get your test suite to run, but if you can show me how to I can run the tests and check if there are any regressions.

Thank you :)