### PR TITLE
Fix: correct reloading for bundles with external dependencies

### DIFF
--- a/src/client/reloadUtils.js
+++ b/src/client/reloadUtils.js
@@ -36,6 +36,7 @@ export function diff(modules, newModules, newEntryId) {
   const dependencies = {}
   function resolveDeps(mod) {
     const deps = values(mod.deps)
+    if (!deps) return;
     dependencies[mod.id] = deps
     deps.forEach(d => {
       if (!dependencies[d]) resolveDeps(newModules[d])

--- a/src/client/reloadUtils.js
+++ b/src/client/reloadUtils.js
@@ -36,10 +36,9 @@ export function diff(modules, newModules, newEntryId) {
   const dependencies = {}
   function resolveDeps(mod) {
     const deps = values(mod.deps)
-    if (!deps) return;
     dependencies[mod.id] = deps
     deps.forEach(d => {
-      if (!dependencies[d]) resolveDeps(newModules[d])
+      if (!dependencies[d] && newModules[d]) resolveDeps(newModules[d])
     })
   }
   resolveDeps(newModules[newEntryId])


### PR DESCRIPTION
Here is my build script (Makefile)

```bash
start:
	exec browserify \
		--require react \
		--require react-dom \
		--outfile app/dist/vendor.js
	@NODE_ENV="development" NODE_PATH="node_modules:app" exec watchify \
		--entry app/index.js \
		--external react \
		--external react-dom \
		--transform babelify \
		--transform envify \
		# FIXME: it doesn't work with external deps
		# --plugin livereactload
		--debug --verbose \
		--outfile app/dist/bundle.js &
	exec http-server -p 3000 app
```

The problem: after I'm updating some module that requires external module (like React in my case) livereactload raises an exception in the function I've updated.