### PR TITLE
Support custom or no client

### DIFF
--- a/src/client/main.js
+++ b/src/client/main.js
@@ -2,10 +2,10 @@ const startClient  = require("./startClient"),
       handleChange = require("./handleChange"),
       {info}       = require("./console")
 
-export default function client(opts) {
+export default function client(opts, start = startClient) {
   const scope$$ = window.__livereactload$$
   scope$$.options = opts
-  startClient(scope$$, {
+  start(scope$$, {
     change(msg) {
       info("Bundle changed")
       handleChange(scope$$, msg.data)


### PR DESCRIPTION
PR for #74. It adds a `client` option to the browserify plugin. Defaults to `true`, with behavior unchanged. When `false`, the line `require("livereactload/client", entryId$$)` is not included at all. Any other value is taken as the path or module id of a custom client, resulting in

```js
require("livereactload/client", entryId$$).call(null, <clientOpts>, require(<customClient>, entryId$$));
require("./<origFilename>", entryId$$);
```

Here's an example of a custom client: [vweevers/livereactload-chrome#feature/custom-client](https://github.com/vweevers/livereactload-chrome/tree/feature/custom-client)