### PR TITLE
Add browserify-hmr suggestion to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,9 @@ LiveReactload in action:
 If you are a Webpack user, you probably want to check
 **[react-transform-boilerplate](https://github.com/gaearon/react-transform-boilerplate)**.
 
+If you want to stick with browserify, but use the Hot Module Reloading API (like webpack), you could use: **[browserify-hmr](https://github.com/AgentME/browserify-hmr)**, **[babel-plugin-react-transform](https://github.com/gaearon/babel-plugin-react-transform)** and
+**[react-transform-hmr](https://github.com/gaearon/react-transform-hmr)**
+
 
 ## Usage
 


### PR DESCRIPTION
The HMR API looks pretty good. With browserify-hmr this looks set to become the standard API for hot reloading. I am wondering if this module might end up being deprecated in favour of browserify-hmr and react-transform-hmr?

Anyway, I thought it would be useful to add the suggestion to the "other implementations" section of the README.

Thanks.