### PR TITLE
Auto find host based on window.location.hostname

### DIFF
--- a/src/browserify-plugin/main.js
+++ b/src/browserify-plugin/main.js
@@ -9,7 +9,7 @@ import {values} from "../common"
 module.exports = function LiveReactloadPlugin(b, opts = {}) {
   const {
     port = 4474,
-    host = "localhost",
+    host = null,
     client = true
     } = opts
 
@@ -19,7 +19,7 @@ module.exports = function LiveReactloadPlugin(b, opts = {}) {
 
   const clientOpts = {
     port: Number(port),
-    host: host.toString()
+    host: host
   }
 
   b.on("reset", addHooks)

--- a/src/client/startClient.js
+++ b/src/client/startClient.js
@@ -26,5 +26,5 @@ export default function startClient(scope$$, onMsg) {
 
 function makeHostUrl({options: {host, port}}) {
   const protocol = window.location.protocol === "https:" ? "wss" : "ws"
-  return `${protocol}://${host}:${port}`
+  return `${protocol}://${host || window.location.hostname}:${port}`
 }


### PR DESCRIPTION
When I want to use livereactload on another machine, like a tablet or a phone, I don't want to have to find my ip and set the host flag if the browser can do it for me :)

Let me know if you don't agree with the solution and have another solution in mind. I would appreciate it if you published up the changes if you merge.

Thanks.