### PR TITLE
Added error handler to prevent crash on ungraceful websocket disconnect.

### DIFF
--- a/src/browserify-plugin/reloadServer.js
+++ b/src/browserify-plugin/reloadServer.js
@@ -2,6 +2,12 @@ import {Server} from "ws"
 import {log} from "./console"
 import {pairs} from "../common"
 
+function logError(error) {
+  if (error) {
+    log(error)
+  }
+}
+
 export function startServer({port}) {
   const wss = new Server({port})
 
@@ -16,7 +22,7 @@ export function startServer({port}) {
         client.send(JSON.stringify({
           type: "change",
           data: metadata
-        }))
+        }), logError)
       })
     },
     notifyBundleError(error) {
@@ -27,7 +33,7 @@ export function startServer({port}) {
         client.send(JSON.stringify({
           type: "bundle_error",
           data: { error: error.toString() }
-        }))
+        }), logError)
       })
     }
   }


### PR DESCRIPTION
I'm having issues when I refresh a page while `livereactload` is trying to push updates to the client. This causes the reload server to crash because the client disconnects.

After looking at the [ws](https://www.npmjs.com/package/ws#error-handling-best-practices) docs, I found an optional callback for handling errors. This should prevent the websocket server from crashing. However, I am not sure how to add tests for this edge case. Any ideas?

Thanks!