### PR TITLE
Fixed TypeError in the Gulp example

### DIFF
--- a/examples/03-build-systems/gulpfile.js
+++ b/examples/03-build-systems/gulpfile.js
@@ -57,7 +57,7 @@ gulp.task("watch:js", function() {
 
 gulp.task("watch:server", function() {
   nodemon({ script: "server.js", ext: "js", ignore: ["gulpfile.js", "bundle.js", "node_modules/*"] })
-    .on("change", [])
+    .on("change", function () {})
     .on("restart", function () {
       console.log("Server restarted")
     })


### PR DESCRIPTION
`nodemon@1.9.1` seems to throw `TypeError: listener must be a function`, replaced empty array `[]` with an noop function which fixed the issue for me.