### PR TITLE
Allow for modules to be excluded from Bundle

### DIFF
--- a/src/browserify-plugin/main.js
+++ b/src/browserify-plugin/main.js
@@ -112,11 +112,20 @@ function LiveReactloadPlugin(b, opts = {}) {
       function flush(next) {
         const pathById = _.fromPairs(_.toPairs(mappings).map(([file, [s, d, {browserifyId: id}]]) => [id, file]))
         const idToPath = id =>
-          pathById[id] || (_.isString(id) && id) || throws("Full path not found for id: " + id)
+          pathById[id] || (_.isString(id) && id)
+
+        const depsToPaths = deps =>
+          _.reduce(deps, (m, v, k) => {
+            let id = idToPath(v);
+            if (id) {
+              m[k] = id;
+            }
+            return m;
+          }, {})
 
         const withFixedDepsIds = _.mapValues(mappings, ([src, deps, meta]) => [
           src,
-          _.mapValues(deps, idToPath),
+          depsToPaths(deps),
           meta
         ])
         const args = [

--- a/test/app/package.json
+++ b/test/app/package.json
@@ -4,7 +4,7 @@
   "scripts": {
     "start": "babel-node server.js & npm run watch:app & npm run watch:extra & wait",
     "bundle:vendor": "browserify -o bundle.vendor.js -v -t babelify -r react -r react-dom",
-    "watch:app": "watchify site.js -v -t babelify -p [ livereactload --port=4477 ] -x react -x react-dom --ig -o bundle.app.js",
+    "watch:app": "watchify site.js -v -t babelify -p [ livereactload --port=4477 ] -x react -x react-dom -u clockmaker --ig -o bundle.app.js",
     "watch:extra": "watchify extra.js -v -s Extra -t babelify -p [ livereactload --port=4478 ] -x react -x react-dom -o bundle.extra.js"
   },
   "dependencies": {
@@ -23,6 +23,7 @@
   "devDependencies": {
     "babel-plugin-react-transform": "^2.0.2",
     "browserify": "^13.0.1",
+    "clockmaker": "^2.0.0",
     "livereactload": "file:../..",
     "react-proxy": "^1.1.8",
     "watchify": "^3.7.0"

--- a/test/app/site.js
+++ b/test/app/site.js
@@ -2,12 +2,19 @@ import React from "react"
 import { render } from "react-dom"
 import App from "./.src/app"
 
+try {
+  window._clockMaker = require('clockmaker');
+} catch (err) {
+  console.warn('Clockmaker not found!');
+}
+
 // we are requiring redux here even though it's not used because
 // redux 3.0.0 contains some dependencies that are de-duplicated
 // by Browserify, thus breaking all the time -- we can get most
 // of these bugs caught by adding this require (the tests get broken
 // when dedupe handling gets broken)
 require("redux")
+
 
 console.log("Increment site.js reload counter...")
 window._siteReloadCounter = "_siteReloadCounter" in window ? window._siteReloadCounter + 1 : 0


### PR DESCRIPTION
First of all, thanks for this great module!

In order to get HMR working with Electron.js apps I need to be able to exclude certain modules from being bundled, e.g. `electron`. But when I use Browserify's exclude option the livereactload browserify plugin fails to work. 

This PR fixes that. I've also updated the tests.