### PR TITLE
Fixes #127

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,8 +28,10 @@
   },
   "dependencies": {
     "cli-color": "1.1.0",
+    "convert-source-map": "1.3.0",
     "lodash": "4.13.1",
     "md5": "2.1.0",
+    "offset-sourcemap-lines": "1.0.0",
     "through2": "2.0.1",
     "umd": "3.0.1",
     "ws": "1.1.1"

--- a/src/browserify-plugin/main.js
+++ b/src/browserify-plugin/main.js
@@ -153,7 +153,8 @@ function LiveReactloadPlugin(b, opts = {}) {
           clientOpts
         ]
         let bundleSrc =
-          `(${loader.toString()})(${args.map(a => JSON.stringify(a, null, 2)).join(", ")});`
+          `(${loader.toString()})(${args.map(a => JSON.stringify(a, null, 2)).join(", ")});
+            ${__livereactload_loadAsModule.toString()};`
         if (standalone) {
           bundleSrc = umd(standalone, `return ${bundleSrc}`)
         }
@@ -170,6 +171,15 @@ function LiveReactloadPlugin(b, opts = {}) {
   function throws(msg) {
     throw new Error(msg)
   }
+}
+
+function __livereactload_loadAsModule(__livereactload_source, __livereactload_sourcemap) {
+  return eval(
+    'function __livereactload_module(require, module, exports){\n' +
+    __livereactload_source +
+    '\n}; __livereactload_module;' +
+    (__livereactload_sourcemap || '')
+  );
 }
 
 module.exports = LiveReactloadPlugin

--- a/src/browserify-plugin/main.js
+++ b/src/browserify-plugin/main.js
@@ -18,6 +18,7 @@ function LiveReactloadPlugin(b, opts = {}) {
     client = true,
     dedupe = true,
     debug = false,
+    basedir = process.cwd(),
     'ssl-cert': sslCert = null,
     'ssl-key': sslKey = null,
     } = opts
@@ -101,11 +102,15 @@ function LiveReactloadPlugin(b, opts = {}) {
         const converter = convertSourceMaps.fromSource(source)
         let sourceWithoutMaps = source
         let adjustedSourcemap = ''
+        let hash;
 
         if (converter) {
-          converter.setProperty('sources', [file])
           sourceWithoutMaps = convertSourceMaps.removeComments(source)
+          hash = md5(sourceWithoutMaps)
+          converter.setProperty('sources', [file.replace(basedir, hash)])
           adjustedSourcemap = convertSourceMaps.fromObject(offsetSourceMaps(converter.toObject(), 1)).toComment()
+        } else {
+          hash = md5(source)
         }
 
         if (entry) {

--- a/src/reloading.js
+++ b/src/reloading.js
@@ -84,7 +84,7 @@ function loader(mappings, entryPoints, options) {
     var body = mapping[0];
     if (typeof body !== "function") {
       debug("Compiling module", mapping[2])
-      var compiled = loadAsModule(body, mapping[2].sourcemap);
+      var compiled = __livereactload_loadAsModule(body, mapping[2].sourcemap);
       mapping[0] = compiled;
       mapping[2].source = body;
     }
@@ -427,15 +427,6 @@ function loader(mappings, entryPoints, options) {
 
   function error(msg) {
     console.error("LiveReactload ::", msg);
-  }
-
-  function loadAsModule(__livereactload_source, __livereactload_sourcemap) {
-    return eval(
-      'function __livereactload_module(require, module, exports){\n' +
-      __livereactload_source +
-      '\n}; __livereactload_module;' +
-      (__livereactload_sourcemap || '')
-    );
   }
 
 }

--- a/src/reloading.js
+++ b/src/reloading.js
@@ -84,7 +84,7 @@ function loader(mappings, entryPoints, options) {
     var body = mapping[0];
     if (typeof body !== "function") {
       debug("Compiling module", mapping[2])
-      var compiled = new Function("require", "module", "exports", body);
+      var compiled = loadAsModule(body, mapping[2].sourcemap);
       mapping[0] = compiled;
       mapping[2].source = body;
     }
@@ -428,8 +428,17 @@ function loader(mappings, entryPoints, options) {
   function error(msg) {
     console.error("LiveReactload ::", msg);
   }
-}
 
+  function loadAsModule(__livereactload_source, __livereactload_sourcemap) {
+    return eval(
+      'function __livereactload_module(require, module, exports){\n' +
+      __livereactload_source +
+      '\n}; __livereactload_module;' +
+      (__livereactload_sourcemap || '')
+    );
+  }
+
+}
 
 module.exports = loader;
 module.exports["default"] = loader;


### PR DESCRIPTION
This fixes the misalignment of the sourcemaps. However, two problems remain:

1. Instead of using `new Function(...)` I had to use `eval`. I couldn't figure out a way to get the `Function` constructor to read a sourcemap, probably because sourcemaps need to be at the end of a file. There's no way to do that with a `Function` constructor, though I'd love to be wrong. The problem is that with `eval` we lose the scoping advantages of `Function`. That means the modules have access to all the local vars from the `loader` function. The way to fix this is to sideload the `loadAsModule` method. Are there are other side effects of this change I haven't noticed?

2. When a new module is loaded to replace an old one, the sourcemap is discarded because the source file has the same name. The workaround here is to make the name unique somehow, and luckily we have a hash right ready for this purpose already! I already use the absolute filename for the sourcemap so that the whole `-t [ babelify --absoluteSourceMaps]` thing isn't needed. We need to figure out the best way to make this work with the hash. I'm thinking we figure out the `cwd` and replace it with the hash, so that `/home/username/project/src/filename.js` becomes `abcdef1234567890/src/filename.js` and so on with different hashes for subsequent revisions.

Despite these problems I'm opening the PR to start a discussion. I plan on addressing these two issues as described unless someone has a suggestion.