### PR TITLE
source maps: leave source filename intact, add hash to end

### DIFF
--- a/src/browserify-plugin/main.js
+++ b/src/browserify-plugin/main.js
@@ -102,12 +102,19 @@ function LiveReactloadPlugin(b, opts = {}) {
         const converter = convertSourceMaps.fromSource(source)
         let sourceWithoutMaps = source
         let adjustedSourcemap = ''
+		let hashedSourceFiles = []
         let hash;
 
         if (converter) {
           sourceWithoutMaps = convertSourceMaps.removeComments(source)
           hash = md5(sourceWithoutMaps)
-          converter.setProperty('sources', [file.replace(basedir, hash)])
+
+          const sources = converter.getProperty('sources')
+          for (let i=0; i < sources.length; i++) {
+            hashedSourceFiles[i] = sources[i] + "?version=" + hash
+          }
+          converter.setProperty('sources', hashedSourceFiles)
+
           adjustedSourcemap = convertSourceMaps.fromObject(offsetSourceMaps(converter.toObject(), 1)).toComment()
         } else {
           hash = md5(source)


### PR DESCRIPTION
PR to fix #141

Simply adds a hash to the end of the existing source filename, rather than completely overwriting the source filename.  

Example source file: 
`src/sub/file.coffee`
Previously appeared as: 
`md5_hash/compiled_destination/file.js`
Now appears as: 
`src/sub/file.coffee?version=md5_hash`

Admittedly, adding the hash to the filename will pollute the console somewhat.  But long filenames are truncated with '...' in the console & easily ignored.  Whereas putting the hash in the path made source browsers nearly useless, since each file appeared in its own unique folder.