### PR TITLE
preserve source filenames, only add hash on change

### DIFF
--- a/src/browserify-plugin/main.js
+++ b/src/browserify-plugin/main.js
@@ -107,7 +107,6 @@ function LiveReactloadPlugin(b, opts = {}) {
         if (converter) {
           sourceWithoutMaps = convertSourceMaps.removeComments(source)
           hash = md5(sourceWithoutMaps)
-          converter.setProperty('sources', [file.replace(basedir, hash)])
           adjustedSourcemap = convertSourceMaps.fromObject(offsetSourceMaps(converter.toObject(), 1)).toComment()
         } else {
           hash = md5(source)


### PR DESCRIPTION
Fix for #141

Now the MD5 hash will only be added to the source filename when we reload an existing script with sourcemaps.  This is much cleaner in the console and source browser.

Source filename in source maps will be preserved, so that compile-to-JS languages are not negatively affected.

Made my modifications on the development branch as suggested in PR #142