### PR TITLE
Don't append :80 to url for port 80

### DIFF
--- a/src/reloading.js
+++ b/src/reloading.js
@@ -66,7 +66,10 @@ function loader(mappings, entryPoints, options) {
       return;
     }
     var protocol = window.location.protocol === "https:" ? "wss" : "ws";
-    var url = protocol + "://" + (options.host || window.location.hostname) + ":" + options.port;
+    var url = protocol + "://" + (options.host || window.location.hostname);
+    if (options.port != 80) {
+      url = url + ":" + options.port;
+    }
     var ws = new WebSocket(url);
     ws.onopen = function () {
       info("WebSocket client listening for changes...");


### PR DESCRIPTION
Long story short: as of Chrome 58.0.3018.3, CSP headers parsing for `wss://*` accepts `wss://site` as allowed, but does NOT accept `wss:site:80`. This tweak removes the unneeded `:80` and, in doing so, allows the use of livereactload in situations (i.e. Shopify theme design) where the dev doesn't have control over the CSP settings the server sends.
