### PR TITLE
Fixes #147 (rev replaced with hash)

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,8 +29,9 @@
   "dependencies": {
     "cli-color": "1.1.0",
     "convert-source-map": "1.3.0",
+    "crc": "3.4.4",
+    "left-pad": "1.1.3",
     "lodash": "4.17.4",
-    "md5": "2.2.1",
     "offset-sourcemap-lines": "1.0.0",
     "through2": "2.0.3",
     "umd": "3.0.1",


### PR DESCRIPTION
* Replaced `md5` with `crc` because crc will produce a short 32-bit digest (md5 is 128-bit). Also faster/simpler, though that doesn't really matter.
* Using `left-pad` and `Buffer` to encode the 32-bit crc digest as a base64-encoded string. The `left-pad` is used because crc returns a Number which sometimes results in a "short" string (eg `12345667` instead of `01234567`), and `Buffer` with `hex` decoding expects a series of character *pairs*. We strip the equal signs base64 uses for padding (those are the characters we saved). Ideally, it'd be nice to use base65536 instead of base64, but I'm worried we'll run into some weird Chrome bugs or something. I'd like to try this anyway in the future, it would reduce the hash length to two characters.
* Removed the revision code because it was being performed during the hot reloading and we need to add the hash during the initial file processing
* I realized how I messed up (@pizza2code) the file names in my previous PR, I was using Browserify's filename and blowing away the filename in the sourcemap. Now I'm pulling the filename from the sourcemap and appending the hash to that.

I'd like to call the `?version=hash` param as `?v=hash` instead to make it shorter but I promised @pizza2code I'd make it explicit. It's ultimately up to you, change it to whatever you want.