### PR TITLE
Allow all major version ranges

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,15 +27,15 @@
     "test": "babel-tape-runner test/**/*Test.js ; EXIT_VALUE=$? ; killall node ; exit $EXIT_VALUE"
   },
   "dependencies": {
-    "cli-color": "1.1.0",
-    "convert-source-map": "1.3.0",
-    "crc": "3.4.4",
-    "left-pad": "1.1.3",
-    "lodash": "4.17.11",
-    "offset-sourcemap-lines": "1.0.0",
-    "through2": "2.0.3",
-    "umd": "3.0.1",
-    "ws": "6.1.x",
+    "cli-color": "^1.1.0",
+    "convert-source-map": "^1.3.0",
+    "crc": "^3.4.4",
+    "left-pad": "^1.1.3",
+    "lodash": "^4.17.11",
+    "offset-sourcemap-lines": "^1.0.0",
+    "through2": "^2.0.3",
+    "umd": "^3.0.1",
+    "ws": "^6.1.x",
     "react-proxy": "^1.1.8"
   },
   "devDependencies": {


### PR DESCRIPTION
Otherwise, we end up with a lot of duplicate deps in our projects